### PR TITLE
Start asking for USB mode on plug by default

### DIFF
--- a/sparse/etc/usb-moded/80-use-ask-mode.ini
+++ b/sparse/etc/usb-moded/80-use-ask-mode.ini
@@ -1,0 +1,2 @@
+[usbmode]
+mode=ask


### PR DESCRIPTION
Before this had to be chosen in system settings before re-plugging.
This is default behavior for example on the [Sony Nile (Xperia XA2) devices](https://github.com/mer-hybris/droid-config-sony-nile/blob/master/sparse/etc/usb-moded/usb-moded.ini).